### PR TITLE
gitignore _recipedb directory.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+_recipedb/*


### PR DESCRIPTION
Prevents any _recipedb folders from being committed. Just in case you're using the repo folder to test the site.