### PR TITLE
Prevent card images being too tall.

### DIFF
--- a/frontends/onthehouse_flask/static/common.css
+++ b/frontends/onthehouse_flask/static/common.css
@@ -51,7 +51,12 @@ Organization:
         color:5c3333;
     }
 
+    .recipe-box
+    {
+      height: 280px;
+      margin-bottom: 20px;
+    }
     .recipe-box img{
       max-width: 100%;
-      height: auto;
+      max-height: 180px;
     }

--- a/frontends/onthehouse_flask/templates/macros.html
+++ b/frontends/onthehouse_flask/templates/macros.html
@@ -7,7 +7,7 @@
         <div style="text-align:center; " class="recipe-box">
             <a style="text-decoration: none;" href="/recipe/{{recipe.id}}/{{recipe.slug}}">
                 <div class="well" style="height:280px; color:b30000">
-                    <img height="120" class="img-rounded" alt="Recipe Image" src="{{'/static/default_recipe_pic.jpg' if recipe.recipe_image_id is none else '/image/' + recipe.recipe_image_id }}">
+                    <img class="img-rounded" alt="Recipe Image" src="{{'/static/default_recipe_pic.jpg' if recipe.recipe_image_id is none else '/image/' + recipe.recipe_image_id }}">
                     <h4>{{ recipe.name }}</h4>
                     <h5>Added: {{ recipe.date_added|unix_to_human }}</h5>
                 </div>
@@ -19,7 +19,7 @@
         <div style="text-align:center; " class="recipe-box">
             <a style="text-decoration: none;" href="/recipe/{{recipe.id}}/{{recipe.slug}}">
                 <div class="well">
-                    <img height="240" class="img-rounded" alt="Recipe Image" src="{{'/static/default_recipe_pic.jpg' if recipe.recipe_image_id is none else '/image/' + recipe.recipe_image_id }}">
+                    <img class="img-rounded" alt="Recipe Image" src="{{'/static/default_recipe_pic.jpg' if recipe.recipe_image_id is none else '/image/' + recipe.recipe_image_id }}">
                     <h3>{{ recipe.name }}</h3>
                     <h4>Added: {{ recipe.date_added|unix_to_human }}</h4>
                 </div>
@@ -31,7 +31,7 @@
         <div style="text-align:center; " class="recipe-box">
             <a style="text-decoration: none;" href="/recipe/{{recipe.id}}/{{recipe.slug}}">
                 <div class="well">
-                    <img height = "400" class="img-rounded" alt="Recipe Image" src="{{'/static/default_recipe_pic.jpg' if recipe.recipe_image_id is none else '/image/' + recipe.recipe_image_id }}">
+                    <img class="img-rounded" alt="Recipe Image" src="{{'/static/default_recipe_pic.jpg' if recipe.recipe_image_id is none else '/image/' + recipe.recipe_image_id }}">
                     <h2>{{ recipe.name }}</h2>
                     <h3>Added: {{ recipe.date_added|unix_to_human }}</h3>
                 </div>


### PR DESCRIPTION
By setting height in CSS instead of html props.

This probably breaks the 'm' and 'l' cards but so far we aren't even using them anywhere. So we can add more separate CSS classes if we ever want to.

## Before

![image](https://user-images.githubusercontent.com/7299570/36749648-38c07978-1bb0-11e8-9cc3-b985a51b6891.png)

## After

![image](https://user-images.githubusercontent.com/7299570/36749663-4766903e-1bb0-11e8-8c84-8910a44eebdb.png)
